### PR TITLE
GitHub action for automated build

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,0 +1,44 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - master
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    #
+    # paths:
+    # - some-subfolder/**
+
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        auto-activate-base: false
+        activate-environment: echem
+        environment-file: echem.yml
+        python-version: 3.9
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
+
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_build/html

--- a/echem.yml
+++ b/echem.yml
@@ -3,23 +3,17 @@ channels:
   - conda-forge
   - veloxchem
   - gator
-  - pyscf
 dependencies:
-  - python=3.7 #pyscf is restricted to 3.6 or 3.7
+  - python=3.9
+  - veloxchem>=1.0rc2
+  - multipsi
+  - gator
+  - pyscf
   - jupyter-book
   - matplotlib
   - ghp-import
   - numpy
-  - veloxchem>=1.0rc2
-  - multipsi
-  - gator
   - py3dmol
   - openmm
   - mdanalysis
   - h5py
-#the following is for pyscf
-  - pip
-  - pip:
-    - glibc
-    - pyscf
-


### PR DESCRIPTION
- I've added a GitHub action workflow that builds the webpage and uploads it to the `gh-pages` branch automatically. One needs only push their changes to `master` now.
- pyscf can be installed from the `conda-forge` channel. This package is compatible with newer versions of Python.