### PR TITLE
Fix center of mass equation in vibrations notebook

### DIFF
--- a/docs/mol_struct/vibrations.ipynb
+++ b/docs/mol_struct/vibrations.ipynb
@@ -53,7 +53,7 @@
     "one first determines the center of mass (COM) $\\mathbf{R}^{\\text{COM}}$ in the usual way\n",
     "```{math}\n",
     "%:label: eq:center_of_mass\n",
-    "  \\mathbf{R}^{\\text{COM}} = \\frac{\\sum_{K} m_{K} \\mathbf{R}_K}{\\sum_{K} \\mathbf{R}_K} \n",
+    "  \\mathbf{R}^{\\text{COM}} = \\frac{\\sum_{K} m_{K} \\mathbf{R}_K}{\\sum_{K} m_{K}} \n",
     "```\n",
     "where the sum runs over all atoms $K$, and the origin is then shifted to the COM, $\\mathbf{R}_{K}^{\\text{COM}} = \\mathbf{R}_K - \\mathbf{R}^{\\text{COM}}$. Subsequently, one determines the inertia tensor and diagonalizes it\n",
     "to obtain principal moments and axes of inertia. Next, one needs to find the transformation from mass-weighted Cartesian coordinates to a set of $3N$ coordinates, where the molecule's translation and rotation are separated out,\n",


### PR DESCRIPTION
I believe the divisor should be the total mass.

Thanks for providing these notebooks, by the way, they're great!